### PR TITLE
Fix multiple bugs, serial connection, and startup behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+venv/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 venv/
 *.pyc
+DearPyGui/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 *.pyc
 DearPyGui/
 dist/
+config.txt

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -2154,6 +2154,7 @@ def build_gui(protocol):
             if device in p:
                 dpg.set_value("comport", p)
                 break
+    return device
 
 async def main():
     global TCP,debug,log,protocol,is_user_admin
@@ -2230,14 +2231,15 @@ async def main():
 
     if radio.dpg_enabled == True:
         dpg.create_context()
-        build_gui(protocol)
+        saved_device = build_gui(protocol)
         dpg.create_viewport(title="TYT TH9800 CAT Control", width=575, height=580, resizable=False)
         dpg.setup_dearpygui()
         dpg.show_viewport()
 
-        # Auto-connect to saved serial device if a valid port is selected
+        # Auto-connect only if a device was previously saved in config.
+        # A blank device field means first run or intentional reset — skip auto-connect.
         comport_value = dpg.get_value("comport")
-        if comport_value and ":" in comport_value:
+        if saved_device and comport_value and ":" in comport_value:
             auto_comport = comport_value[0:comport_value.index(":")]
             auto_baudrate = dpg.get_value("baud_rate")
             if not loop.is_running():

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -249,12 +249,15 @@ class TCP:
                 self.tcpserver_loggedin = False
                 self.tcpserver_login_count = 0
 
-                writer.close()
-                if sys.platform != "win32": # On Windows, skip wait_closed entirely to avoid WinError 64
-                    try:
-                        await writer.wait_closed()
-                    except (ConnectionResetError, BrokenPipeError, OSError):
-                        pass
+                if writer.transport and not writer.transport.is_closing():
+                    writer.transport.abort()
+                else:
+                    writer.close()
+                    if sys.platform != "win32":
+                        try:
+                            await writer.wait_closed()
+                        except (ConnectionResetError, BrokenPipeError, OSError):
+                            pass
             except:
                 None
 

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -14,6 +14,49 @@ protocol = None
 read_loop_future = None
 write_loop_future = None
 
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.txt")
+CONFIG_DEFAULTS = {
+    "baud_rate": "19200",
+    "device": "FT232R USB UART",
+    "host": "",
+    "port": "",
+    "password": "",
+}
+
+def load_config():
+    if not os.path.exists(CONFIG_PATH):
+        save_config(CONFIG_DEFAULTS)
+        return dict(CONFIG_DEFAULTS)
+    settings = dict(CONFIG_DEFAULTS)
+    with open(CONFIG_PATH, "r") as f:
+        for line in f:
+            line = line.strip()
+            if "=" in line:
+                key, _, value = line.partition("=")
+                key = key.strip()
+                if key in settings:
+                    settings[key] = value.strip()
+    return settings
+
+def save_config(settings):
+    with open(CONFIG_PATH, "w") as f:
+        for key in CONFIG_DEFAULTS:
+            f.write(f"{key}={settings.get(key, '')}\n")
+
+def save_current_settings():
+    comport = dpg.get_value("comport")
+    device = ""
+    if comport and ": " in comport:
+        device = comport.split(": ", 1)[1]
+    settings = {
+        "baud_rate": dpg.get_value("baud_rate"),
+        "device": device,
+        "host": dpg.get_value("tcp_host_text"),
+        "port": dpg.get_value("tcp_port_text"),
+        "password": dpg.get_value("tcp_pass_text"),
+    }
+    save_config(settings)
+
 def printd(msg):
     if debug == True:
         print(msg)
@@ -1355,10 +1398,12 @@ def tcp_connect_callback(sender, app_data, user_data):
     password = dpg.get_value("tcp_pass_text")
     protocol = user_data['protocol']
     label = user_data['label']
-    
+
     if password == None:
         password = ""
-    
+
+    save_current_settings()
+
     if label == "Start Server":
         tag = "tcp_startserver_button"
         label = dpg.get_item_label(tag)
@@ -1574,9 +1619,9 @@ def vol_callback(sender, app_data, user_data):
     
     radio.set_volume(vfo=vfo,vol=app_data)
 
-async def connect_serial_async(protocol, comport, baudrate):
+async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
     global TCP
-    
+
     radio = protocol.radio
     transport = None
 
@@ -1613,16 +1658,19 @@ async def connect_serial_async(protocol, comport, baudrate):
         cat_controller = CATController(radio=radio)
         radio.cat = cat_controller
         rigctl_server = RigctlServer(cat_controller)
-        
+
         if radio.rigctl_server == True:
             dpg.configure_item("getstate_button", show=True)
             radio.get_freq(vfo=RADIO_VFO.LEFT)
             radio.get_freq(vfo=RADIO_VFO.RIGHT)
             await rigctl_server.start()
-        
+
         await asyncio.sleep(2)
         if radio.dpg_enabled == True:
-            dpg_notification_window(title="Radio Initialized", message="Radio connected and initialized successfully!")
+            with dpg.window(label="Radio Initialized", modal=True, no_close=True, pos=[22, 100]) as modal_id:
+                dpg.add_text(f"Connected to {comport} successfully!")
+            await asyncio.sleep(3)
+            dpg.delete_item(modal_id)
         else:
             print("Radio connected and initialized successfully!")
 
@@ -1630,8 +1678,8 @@ async def connect_serial_async(protocol, comport, baudrate):
     except Exception as e:
         print(f"Connection failed: {e}")
         if radio.dpg_enabled == True:
-            with dpg.window(label="Error", modal=True, no_close=True) as modal_id:
-                dpg.add_text(e, wrap=300)
+            with dpg.window(label="Connection Failed", modal=True, no_close=True) as modal_id:
+                dpg.add_text(f"Auto-connect to {comport} failed:\n{e}" if auto_dismiss else e, wrap=300)
                 dpg.add_button(label="Ok", width=75, user_data=(modal_id, True), callback=cancel_callback)
             dpg.set_item_pos(modal_id, [120, 100])
         return None
@@ -1689,6 +1737,8 @@ def port_selected_callback(sender, app_data, user_data):
         dpg.set_item_pos(modal_id, [120, 100])
         return
     
+    save_current_settings()
+
     if not loop.is_running():
         threading.Thread(target=start_event_loop, daemon=True).start()
     protocol.reset_ready()
@@ -2091,6 +2141,20 @@ def build_gui(protocol):
     with dpg.handler_registry():
         dpg.add_key_press_handler(callback=handle_key_press)
 
+    # Load persistent settings from config file
+    settings = load_config()
+    dpg.set_value("baud_rate", settings["baud_rate"])
+    dpg.set_value("tcp_host_text", settings["host"])
+    dpg.set_value("tcp_port_text", settings["port"])
+    dpg.set_value("tcp_pass_text", settings["password"])
+    # Match saved device description against available ports
+    device = settings["device"]
+    if device:
+        for p in ports:
+            if device in p:
+                dpg.set_value("comport", p)
+                break
+
 async def main():
     global TCP,debug,log,protocol,is_user_admin
     parser = argparse.ArgumentParser(description="Example Python app with command-line arguments.")
@@ -2170,6 +2234,19 @@ async def main():
         dpg.create_viewport(title="TYT TH9800 CAT Control", width=575, height=580, resizable=False)
         dpg.setup_dearpygui()
         dpg.show_viewport()
+
+        # Auto-connect to saved serial device if a valid port is selected
+        comport_value = dpg.get_value("comport")
+        if comport_value and ":" in comport_value:
+            auto_comport = comport_value[0:comport_value.index(":")]
+            auto_baudrate = dpg.get_value("baud_rate")
+            if not loop.is_running():
+                threading.Thread(target=start_event_loop, daemon=True).start()
+            protocol.reset_ready()
+            asyncio.run_coroutine_threadsafe(
+                connect_serial_async(protocol, auto_comport, auto_baudrate, auto_dismiss=True),
+                loop
+            )
 
     try:
         if radio.dpg_enabled == True:

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -144,13 +144,13 @@ class TCP:
                     if data == None or data == "":
                         protocol.toggle_rts()
                     else:
-                        protocol.set_rts(bool(data))
+                        protocol.set_rts(data.strip().lower() in ('true', '1', 'on'))
                     return str(protocol.transport.serial.rts)
                 case "dtr":
                     if data == None or data == "":
                         protocol.toggle_dtr()
                     else:
-                        protocol.set_dtr(bool(data))
+                        protocol.set_dtr(data.strip().lower() in ('true', '1', 'on'))
                     return str(protocol.transport.serial.dtr)
                 case "exit":
                     return "return"

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -249,15 +249,11 @@ class TCP:
                 self.tcpserver_loggedin = False
                 self.tcpserver_login_count = 0
 
-                if writer.transport and not writer.transport.is_closing():
-                    writer.transport.abort()
-                else:
-                    writer.close()
-                    if sys.platform != "win32":
-                        try:
-                            await writer.wait_closed()
-                        except (ConnectionResetError, BrokenPipeError, OSError):
-                            pass
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (ConnectionResetError, BrokenPipeError, OSError):
+                    pass
             except:
                 None
 

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -251,7 +251,10 @@ class TCP:
 
                 writer.close()
                 if sys.platform != "win32": # On Windows, skip wait_closed entirely to avoid WinError 64
-                    await writer.wait_closed()
+                    try:
+                        await writer.wait_closed()
+                    except (ConnectionResetError, BrokenPipeError, OSError):
+                        pass
             except:
                 None
 

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -2438,8 +2438,42 @@ async def main():
             print(f"TCP server ready — waiting for serial connect via web UI or TCP command")
             print(f"  Serial device: {args.comport} @ {args.baudrate}")
 
-            while True:
-                await asyncio.sleep(10)
+            # Register SIGTERM handler so systemd stop triggers clean shutdown
+            import signal
+            _shutdown_event = asyncio.Event()
+            def _sigterm_handler(signum, frame):
+                print("\nSIGTERM received — shutting down...")
+                loop.call_soon_threadsafe(_shutdown_event.set)
+            signal.signal(signal.SIGTERM, _sigterm_handler)
+            signal.signal(signal.SIGINT, _sigterm_handler)
+
+            try:
+                await _shutdown_event.wait()
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                pass
+            finally:
+                # Clean up serial connection
+                if protocol.transport and not protocol.transport.is_closing():
+                    print("  Closing serial port...")
+                    try:
+                        protocol.transport.serial.dtr = False
+                    except Exception:
+                        pass
+                    protocol.transport.close()
+                # Clean up TCP server
+                if TCP.tcpserver is not None:
+                    try:
+                        TCP.tcpserver.close()
+                    except Exception:
+                        pass
+                if TCP.tcpserver_server is not None:
+                    try:
+                        TCP.tcpserver_server.close()
+                    except Exception:
+                        pass
+                TCP.tcpserver_ready = False
+                print("  Headless server shut down cleanly.")
+            return  # Skip GUI path below
         else:
             print("A COM Port and Baud Rate are required to start the command line server!")
 

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -621,6 +621,8 @@ class SerialProtocol(asyncio.Protocol):
         self.transmit_queue = asyncio.Queue()
         self.buffer = bytearray()
         self.radio = radio
+        self._read_task = None
+        self._write_task = None
 
     def set_rts(self, state: bool):
         if TCP.tcpclient_ready == True:
@@ -734,12 +736,35 @@ class SerialProtocol(asyncio.Protocol):
                 # Optionally: log, raise alert, or resync buffer here
 
     def connection_lost(self, exc):
-        print("Connection lost")
-        asyncio.get_event_loop().stop()
-        self.transport.close()
+        if exc:
+            print(f"Connection lost: {exc}")
+        else:
+            print("Connection closed")
+        # Explicitly lower RTS/DTR so the radio sees a clean disconnect
+        try:
+            self.transport.serial.rts = False
+            self.transport.serial.dtr = False
+        except:
+            pass
+        self.ready.clear()
+        # Cancel read/write loop tasks if they exist
+        if hasattr(self, '_read_task') and self._read_task and not self._read_task.done():
+            self._read_task.cancel()
+        if hasattr(self, '_write_task') and self._write_task and not self._write_task.done():
+            self._write_task.cancel()
+        # Update UI to reflect disconnected state
+        if self.radio.dpg_enabled:
+            try:
+                dpg.configure_item("connect_button", label="Connect")
+                dpg.configure_item("dtr_button", show=False)
+                dpg.configure_item("rts_button", show=False)
+                dpg.configure_item("rts_text", show=False)
+                dpg.configure_item("rts_label", show=False)
+            except:
+                pass  # UI items may not exist yet
 
     def send_packet(self, data: bytes):
-        if self.transport and not self.transport.is_closing() or TCP.tcpclient_ready == True:
+        if (self.transport and not self.transport.is_closing()) or TCP.tcpclient_ready == True:
             printd(f"Sending: {data.hex().upper()}")
             self.transmit_queue.put_nowait(data)
             #self.transport.write(data)
@@ -1449,7 +1474,8 @@ def refresh_comports_callback(sender, app_data, user_data):
     dpg.configure_item("comport", default_value=ports[0] if available_ports else "")
 
 def cancel_callback(sender, app_data, user_data):
-    dpg.configure_item(user_data, show=False)
+    modal_id = user_data[0] if isinstance(user_data, tuple) else user_data
+    dpg.delete_item(modal_id)
 
 def dpg_notification_window(title, message):
     with dpg.window(label=title, modal=True, no_close=True, pos=[22, 100]) as modal_id:
@@ -1573,8 +1599,8 @@ async def connect_serial_async(protocol, comport, baudrate):
             dpg.configure_item("radio_window", show=True)
             dpg.configure_item("connection_window", collapsed=True)
             dpg.configure_item("connect_button", label="Disconnect")
-        asyncio.create_task(read_loop(protocol))
-        asyncio.create_task(write_loop(protocol))
+        protocol._read_task = asyncio.create_task(read_loop(protocol))
+        protocol._write_task = asyncio.create_task(write_loop(protocol))
         if TCP.tcpclient_ready == False:
             radio.connect_process = True
 
@@ -1623,7 +1649,29 @@ def port_selected_callback(sender, app_data, user_data):
     baudrate = dpg.get_value("baud_rate")
     
     if label == "Disconnect":
+        # Cancel read/write loops before closing transport
+        if protocol._read_task and not protocol._read_task.done():
+            protocol._read_task.cancel()
+        if protocol._write_task and not protocol._write_task.done():
+            protocol._write_task.cancel()
+        protocol._read_task = None
+        protocol._write_task = None
+        # Explicitly lower RTS/DTR before closing so the radio sees a clean disconnect
+        try:
+            protocol.transport.serial.rts = False
+            protocol.transport.serial.dtr = False
+        except:
+            pass
         protocol.transport.close()
+        protocol.ready.clear()
+        # Drain any stale data from queues
+        while not protocol.receive_queue.empty():
+            try: protocol.receive_queue.get_nowait()
+            except: break
+        while not protocol.transmit_queue.empty():
+            try: protocol.transmit_queue.get_nowait()
+            except: break
+        protocol.buffer.clear()
         print(f"{comport} disconnected.\n")
         dpg.configure_item("connect_button", label="Connect")
         dpg.configure_item("dtr_button", show=False)
@@ -1643,8 +1691,8 @@ def port_selected_callback(sender, app_data, user_data):
     
     if not loop.is_running():
         threading.Thread(target=start_event_loop, daemon=True).start()
-        protocol.reset_ready()
-    
+    protocol.reset_ready()
+
     asyncio.run_coroutine_threadsafe(
         connect_serial_async(protocol, comport, baudrate),
         loop
@@ -1657,38 +1705,56 @@ async def run_dpg():
 
 async def read_loop(protocol: SerialProtocol):
     global TCP
-    while True:
-        packet = await protocol.receive_queue.get()
-        
-        if TCP.tcpserver_ready == True and TCP.tcpserver != None:
-            TCP.tcpserver.write(packet+b'\n')
-            await TCP.tcpserver.drain()
-            packet_processor = SerialPacket(protocol=protocol).process_rx_packet(packet=packet)
-        else:
-            packet_processor = SerialPacket(protocol=protocol).process_rx_packet(packet=packet)
+    try:
+        while True:
+            packet = await protocol.receive_queue.get()
+
+            if TCP.tcpserver_ready == True and TCP.tcpserver != None:
+                TCP.tcpserver.write(packet+b'\n')
+                await TCP.tcpserver.drain()
+                packet_processor = SerialPacket(protocol=protocol).process_rx_packet(packet=packet)
+            else:
+                packet_processor = SerialPacket(protocol=protocol).process_rx_packet(packet=packet)
+    except asyncio.CancelledError:
+        printd("Read loop cancelled")
+    except Exception as e:
+        print(f"Read loop error: {e}")
 
 async def write_loop(protocol: SerialProtocol):
     global TCP
 
-    while True:
-        if TCP.tcpclient_ready == True and TCP.tcpclient != None:
-            try:
-                data = await asyncio.wait_for(protocol.transmit_queue.get(), timeout=.10)
-                printd(f"Send pkt tcp: {data}:{type(data)}")
-                TCP.tcpclient.write(data+b'\n')
-                await TCP.tcpclient.drain()
-                if data.hex().find("aafd0c84ffffffff") == -1: #If match sq/vol cmd skip sleep
-                    await asyncio.sleep(0.15)
-            except:
-                None
-        else:
-            try:
-                data = await asyncio.wait_for(protocol.transmit_queue.get(), timeout=.10) #FIX FOR LINUX FREEZES ON TRANSMIT (Old: #data = await protocol.transmit_queue.get())
-                protocol.transport.write(data)
-                if data.hex().find("aafd0c84ffffffff") == -1: #If match sq/vol cmd skip sleep
-                    await asyncio.sleep(0.15)
-            except:
-                None
+    try:
+        while True:
+            if TCP.tcpclient_ready == True and TCP.tcpclient != None:
+                try:
+                    data = await asyncio.wait_for(protocol.transmit_queue.get(), timeout=.10)
+                    printd(f"Send pkt tcp: {data}:{type(data)}")
+                    TCP.tcpclient.write(data+b'\n')
+                    await TCP.tcpclient.drain()
+                    if data.hex().find("aafd0c84ffffffff") == -1: #If match sq/vol cmd skip sleep
+                        await asyncio.sleep(0.15)
+                except asyncio.TimeoutError:
+                    pass  # Normal timeout, no data to send
+                except (ConnectionError, OSError) as e:
+                    print(f"Write loop TCP error: {e}")
+                    break
+            else:
+                try:
+                    data = await asyncio.wait_for(protocol.transmit_queue.get(), timeout=.10) #FIX FOR LINUX FREEZES ON TRANSMIT (Old: #data = await protocol.transmit_queue.get())
+                    if protocol.transport and not protocol.transport.is_closing():
+                        protocol.transport.write(data)
+                    else:
+                        print("Write loop: transport closed, stopping")
+                        break
+                    if data.hex().find("aafd0c84ffffffff") == -1: #If match sq/vol cmd skip sleep
+                        await asyncio.sleep(0.15)
+                except asyncio.TimeoutError:
+                    pass  # Normal timeout, no data to send
+                except (ConnectionError, OSError, serial.SerialException) as e:
+                    print(f"Write loop serial error: {e}")
+                    break
+    except asyncio.CancelledError:
+        printd("Write loop cancelled")
 
 def handle_key_press(sender, app_data):
     global protocol
@@ -2114,6 +2180,12 @@ async def main():
         pass
     finally:
         if protocol.transport != None:
+            # Explicitly lower RTS/DTR before closing so the radio sees a clean disconnect
+            try:
+                protocol.transport.serial.rts = False
+                protocol.transport.serial.dtr = False
+            except:
+                pass
             protocol.transport.close()
         if radio.dpg_enabled == True:
             dpg.destroy_context()

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -218,7 +218,8 @@ class TCP:
                         writer.write(f"{response2}\n".encode())
                         await writer.drain()
                         
-                        protocol.set_rts(True)
+                        # Don't change RTS on TCP client connect — let the radio
+                        # keep its current RTS state (Radio Controlled for AIOC PTT)
                         protocol.radio.connect_process = True
                         protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.STARTUP)
                         await asyncio.sleep(0.5)

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -1680,9 +1680,8 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
             )
             await protocol.ready.wait()
             protocol.set_dtr(True)
+            protocol.transport.serial.rts = False  # Don't force RTS on connect — let gateway control it
             await asyncio.sleep(0.5)
-            printd(f"Connected to {comport} at {baudrate} baud.")
-            #protocol.set_rts(True) #Enable USB/CAT TX Control - removed: let gateway control RTS state
 
         if radio.dpg_enabled == True:
             dpg.configure_item("rts_button", show=True)
@@ -1717,13 +1716,6 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
             await rigctl_server.start()
 
         await asyncio.sleep(2)
-        if radio.dpg_enabled == True:
-            with dpg.window(label="Radio Initialized", modal=True, no_close=True, pos=[22, 100]) as modal_id:
-                dpg.add_text(f"Connected to {comport} successfully!")
-            await asyncio.sleep(3)
-            dpg.delete_item(modal_id)
-        else:
-            print("Radio connected and initialized successfully!")
 
         return transport
     except Exception as e:

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -1682,7 +1682,7 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
             protocol.set_dtr(True)
             await asyncio.sleep(0.5)
             printd(f"Connected to {comport} at {baudrate} baud.")
-            protocol.set_rts(True) #Enable USB/CAT TX Control
+            #protocol.set_rts(True) #Enable USB/CAT TX Control - removed: let gateway control RTS state
 
         if radio.dpg_enabled == True:
             dpg.configure_item("rts_button", show=True)

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -1926,7 +1926,6 @@ def build_gui(protocol):
             dpg.add_button(label="Single VFO", width=90, callback=button_callback, user_data={"label": "Single VFO", "protocol": protocol, "vfo": RADIO_VFO.NONE})
         dpg.add_spacer(height=5)
         dpg.add_separator()
-        dpg.add_spacer(height=3)
 
         # === PREF/SKIP Channel Icons ===
         with dpg.group(horizontal=True):

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -1,7 +1,10 @@
 from getpass import getpass
 from TH9800_Enums import *
 from time import sleep
-import dearpygui.dearpygui as dpg
+try:
+    import dearpygui.dearpygui as dpg
+except ImportError:
+    dpg = None  # Headless mode — no GUI
 import serial.tools.list_ports,serial_asyncio,asyncio,threading
 import logging,datetime,argparse,platform,ctypes,re,os,sys
 
@@ -109,26 +112,36 @@ class TCP:
 
     async def handle_tcpserver_stream(self, reader, writer):
         global protocol
-        async def process_tcp_cmd(self, cmd, data, writer):
+        # Per-connection auth state (not shared — so one client disconnecting
+        # doesn't kill auth for other connected clients)
+        conn_loggedin = False
+        conn_login_count = 0
+
+        async def process_tcp_cmd(cmd, data, writer):
+            nonlocal conn_loggedin, conn_login_count
             global protocol
-            if cmd != "pass" and cmd != "exit" and self.tcpserver_loggedin == False:
+            if cmd != "pass" and cmd != "exit" and conn_loggedin == False:
                 return "Unauthorized"
 
             match cmd:
                 case "pass":
-                    if self.tcpserver_login_count > 3:
+                    if conn_login_count > 3:
                         return "returnLogin"
                     if data == self.tcpserver_passw:
-                        self.tcpserver_loggedin = True
-                        self.tcpserver_login_count = 0
+                        conn_loggedin = True
+                        conn_login_count = 0
                         return "Login Successful"
                     else:
-                        self.tcpserver_login_count += 1
+                        conn_login_count += 1
                         return "Login Failed"
                 case "data":
+                    if not (protocol.transport and not protocol.transport.is_closing()):
+                        return "serial not connected"
                     protocol.send_packet(data=bytearray.fromhex(data))
                     return "data sent"
                 case "vol":
+                    if not (protocol.transport and not protocol.transport.is_closing()):
+                        return "serial not connected"
                     # !vol LEFT 50 or !vol RIGHT 75
                     parts = data.split() if data else []
                     if len(parts) == 2:
@@ -141,17 +154,136 @@ class TCP:
                         return f"vol {vfo_str} {vol}"
                     return "usage: !vol LEFT|RIGHT 0-100"
                 case "rts":
+                    if not (protocol.transport and not protocol.transport.is_closing()):
+                        return "serial not connected"
                     if data == None or data == "":
                         protocol.toggle_rts()
                     else:
                         protocol.set_rts(data.strip().lower() in ('true', '1', 'on'))
                     return str(protocol.transport.serial.rts)
+                case "ptt":
+                    if not (protocol.transport and not protocol.transport.is_closing()):
+                        return "serial not connected"
+                    # !ptt — toggle PTT using the same logic as the GUI button
+                    radio = protocol.radio
+                    if radio.mic_ptt == False:
+                        radio.mic_ptt = True
+                        radio.vfo_memory[radio.vfo_memory['vfo_active']]['ptt'] = 1
+                        radio.exe_cmd(cmd=RADIO_TX_CMD.MIC_PTT)
+                    else:
+                        radio.mic_ptt = False
+                        radio.vfo_memory[radio.vfo_memory['vfo_active']]['ptt'] = 0
+                        radio.exe_cmd(cmd=RADIO_TX_CMD.MIC_PTT)
+                    return str(radio.mic_ptt)
                 case "dtr":
                     if data == None or data == "":
                         protocol.toggle_dtr()
                     else:
                         protocol.set_dtr(data.strip().lower() in ('true', '1', 'on'))
                     return str(protocol.transport.serial.dtr)
+                case "serial":
+                    # !serial disconnect / !serial connect — cycle the serial port
+                    action = (data or '').strip().lower()
+                    if action == 'disconnect':
+                        if protocol.transport and not protocol.transport.is_closing():
+                            if protocol._read_task and not protocol._read_task.done():
+                                protocol._read_task.cancel()
+                            if protocol._write_task and not protocol._write_task.done():
+                                protocol._write_task.cancel()
+                            protocol._read_task = None
+                            protocol._write_task = None
+                            try:
+                                protocol.transport.serial.dtr = False
+                            except:
+                                pass
+                            protocol.transport.close()
+                            protocol.ready.clear()
+                            while not protocol.receive_queue.empty():
+                                try: protocol.receive_queue.get_nowait()
+                                except: break
+                            while not protocol.transmit_queue.empty():
+                                try: protocol.transmit_queue.get_nowait()
+                                except: break
+                            protocol.buffer.clear()
+                            print("Serial disconnected via TCP")
+                            if protocol.radio.dpg_enabled:
+                                dpg.configure_item("connect_button", label="Connect")
+                                dpg.configure_item("dtr_button", show=False)
+                                dpg.configure_item("rts_button", show=False)
+                                dpg.configure_item("rts_text", show=False)
+                                dpg.configure_item("rts_label", show=False)
+                                dpg.configure_item("fp_rts_button", show=False)
+                                dpg.configure_item("fp_rts_text", show=False)
+                                dpg.configure_item("fp_rts_label", show=False)
+                            return "serial disconnected"
+                        return "serial not connected"
+                    elif action == 'connect':
+                        if protocol.transport and not protocol.transport.is_closing():
+                            return "serial already connected"
+                        # Reconnect using saved config.txt
+                        try:
+                            import serial_asyncio
+                            import serial.tools.list_ports
+                            cfg = load_config()
+                            device_name = cfg.get('device', '')
+                            baudrate = int(cfg.get('baud_rate', 19200))
+                            # Find COM port matching device name
+                            comport = None
+                            for p in serial.tools.list_ports.comports():
+                                port_str = f"{p.device}: {p.description}"
+                                if device_name and device_name in p.description:
+                                    comport = p.device
+                                    break
+                            if not comport:
+                                # Fallback: try first available port
+                                ports = serial.tools.list_ports.comports()
+                                if ports:
+                                    comport = ports[0].device
+                            if not comport:
+                                return "serial no port found"
+                            protocol.reset_ready()
+                            loop = asyncio.get_event_loop()
+                            transport, _ = await serial_asyncio.create_serial_connection(
+                                loop, lambda: protocol, comport, baudrate=baudrate
+                            )
+                            await protocol.ready.wait()
+                            # DTR toggle wakes the radio's serial output
+                            # (without this, data_received never fires on first connect)
+                            protocol.transport.serial.dtr = False
+                            await asyncio.sleep(0.1)
+                            protocol.transport.serial.dtr = True
+                            saved_rts = SerialProtocol._load_rts_state()
+                            protocol.transport.serial.rts = saved_rts
+                            protocol.set_rts(saved_rts)
+                            await asyncio.sleep(0.5)
+                            # Start read/write loops (critical — without these, no data flows)
+                            protocol._read_task = asyncio.create_task(read_loop(protocol))
+                            protocol._write_task = asyncio.create_task(write_loop(protocol))
+                            # STARTUP handshake tells radio to begin sending display data.
+                            # STARTUP_2 response handler internally sends L/R_VOLUME_SQUELCH
+                            # — that's the normal handshake, not a storm.
+                            protocol.radio.connect_process = True
+                            protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.STARTUP)
+                            await asyncio.sleep(3)
+                            print(f"Serial connected via TCP ({comport} @ {baudrate})")
+                            if protocol.radio.dpg_enabled:
+                                dpg.configure_item("connect_button", label="Disconnect")
+                                dpg.configure_item("rts_button", show=True)
+                                dpg.configure_item("dtr_button", show=True)
+                                dpg.configure_item("rts_text", show=True)
+                                dpg.configure_item("rts_label", show=True)
+                                dpg.configure_item("fp_rts_button", show=True)
+                                dpg.configure_item("fp_rts_text", show=True)
+                                dpg.configure_item("fp_rts_label", show=True)
+                            return "serial connected"
+                        except Exception as e:
+                            print(f"Serial connect via TCP failed: {e}")
+                            return f"serial error: {e}"
+                    elif action == 'status':
+                        if protocol.transport and not protocol.transport.is_closing():
+                            return "serial connected"
+                        return "serial disconnected"
+                    return "usage: !serial connect|disconnect|status"
                 case "exit":
                     return "return"
                 case _:
@@ -176,7 +308,7 @@ class TCP:
                 if type(data) == bytearray or type(data) == bytes: #Data received is a radio packet
                     if data.find(b'\xAA\xFD') != -1:
                         printd(f"Data RCVD(hex): {data.hex().upper()}")
-                        if self.tcpserver_loggedin == True:
+                        if conn_loggedin == True:
                             protocol.send_packet(data=data)
                         else:
                             writer.write("Unauthorized\n".encode())
@@ -193,15 +325,15 @@ class TCP:
                     if data != -1:
                         cmd = str(message[1:data])
                         data = str(message[data+1::])
-                        print(f"CMD RCVD1:{{{cmd}}}:{{{data}}}")
+                        printd(f"CMD RCVD1:{{{cmd}}}:{{{data}}}")
                         response = f"CMD{{{cmd}[{data}]}} "
                     else:
                         cmd = str(message[1::])
                         data = ""
-                        print(f"CMD RCVD2:{{{cmd}}}")
+                        printd(f"CMD RCVD2:{{{cmd}}}")
                         response = f"CMD{{{cmd}}} "
 
-                    response2 = await process_tcp_cmd(self=self, cmd=cmd, data=data, writer=writer)
+                    response2 = await process_tcp_cmd(cmd=cmd, data=data, writer=writer)
                     printd(f"Response2:{response2}")
                     
                     if response2 == "return":
@@ -217,17 +349,17 @@ class TCP:
                     elif response2 == "Login Successful":
                         writer.write(f"{response2}\n".encode())
                         await writer.drain()
-                        
-                        # Don't change RTS on TCP client connect — let the radio
-                        # keep its current RTS state (Radio Controlled for AIOC PTT)
-                        protocol.radio.connect_process = True
-                        protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.STARTUP)
-                        await asyncio.sleep(0.5)
-                        protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.L_VOLUME_SQUELCH)
-                        await asyncio.sleep(0.5)
-                        protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.R_VOLUME_SQUELCH)
-                        await asyncio.sleep(2)
-                        
+
+                        # Only run startup sequence if serial is NOT already connected
+                        # (headless mode already ran it — running it again creates a
+                        # command storm that overwhelms the radio's serial interface)
+                        if not (protocol.transport and not protocol.transport.is_closing()):
+                            protocol.radio.connect_process = True
+                            protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.STARTUP)
+                            await asyncio.sleep(3)
+                        else:
+                            print("Serial already connected, skipping post-login startup")
+
                         continue
                     else:
                         response += response2
@@ -242,13 +374,9 @@ class TCP:
         except asyncio.CancelledError:
             print(f"Connection to {addr} cancelled.")
             self.tcpserver_ready = False
-            self.tcpserver_loggedin = False
-            self.tcpserver_login_count = 0
         finally:
             print(f"Connection closed: {addr}")
             try:
-                self.tcpserver_loggedin = False
-                self.tcpserver_login_count = 0
 
                 writer.close()
                 try:
@@ -324,23 +452,25 @@ class TCP:
                             self.tcpclient_server_stop = True
                             break
                         case "rts":
-                            match data:
-                                case "True":
-                                    dpg.set_value("rts_text", "USB Controlled")
-                                    protocol.radio.set_dpg_theme(tag="rts_text",color="green")
-                                    dpg.set_value("fp_rts_text", "USB Controlled")
-                                    protocol.radio.set_dpg_theme(tag="fp_rts_text",color="green")
-                                case "False":
-                                    dpg.set_value("rts_text", "Radio Controlled")
-                                    protocol.radio.set_dpg_theme(tag="rts_text",color="red")
-                                    dpg.set_value("fp_rts_text", "Radio Controlled")
-                                    protocol.radio.set_dpg_theme(tag="fp_rts_text",color="red")
+                            if protocol.radio.dpg_enabled and dpg:
+                                match data:
+                                    case "True":
+                                        dpg.set_value("rts_text", "USB Controlled")
+                                        protocol.radio.set_dpg_theme(tag="rts_text",color="green")
+                                        dpg.set_value("fp_rts_text", "USB Controlled")
+                                        protocol.radio.set_dpg_theme(tag="fp_rts_text",color="green")
+                                    case "False":
+                                        dpg.set_value("rts_text", "Radio Controlled")
+                                        protocol.radio.set_dpg_theme(tag="rts_text",color="red")
+                                        dpg.set_value("fp_rts_text", "Radio Controlled")
+                                        protocol.radio.set_dpg_theme(tag="fp_rts_text",color="red")
                         case "dtr":
-                            match data:
-                                case "True":
-                                    protocol.radio.set_dpg_theme(tag="dtr_button",color="green")
-                                case "False":
-                                    protocol.radio.set_dpg_theme(tag="dtr_button",color="red")
+                            if protocol.radio.dpg_enabled and dpg:
+                                match data:
+                                    case "True":
+                                        protocol.radio.set_dpg_theme(tag="dtr_button",color="green")
+                                    case "False":
+                                        protocol.radio.set_dpg_theme(tag="dtr_button",color="red")
                     continue
                 else:
                     print(f"RCVD:{message}")
@@ -585,7 +715,8 @@ class SerialRadio:
             vol = 100
 
         vfo = str(vfo)
-        dpg.set_value(f"slider_{vfo.lower()}_volume",vol)
+        if self.dpg_enabled and dpg:
+            dpg.set_value(f"slider_{vfo.lower()}_volume",vol)
         payload = self.packet.vol_sq_to_packet(value=vol)
         cmd = RADIO_TX_CMD[f"{vfo}_VOLUME"]
         self.vfo_memory[self.get_vfo(vfo=vfo)]['volume'] = vol
@@ -600,7 +731,8 @@ class SerialRadio:
             sq = 100
 
         vfo = str(vfo)
-        dpg.set_value(f"slider_{vfo.lower()}_squelch",sq)
+        if self.dpg_enabled and dpg:
+            dpg.set_value(f"slider_{vfo.lower()}_squelch",sq)
         payload = self.packet.vol_sq_to_packet(value=sq)
         cmd = RADIO_TX_CMD[f"{vfo}_SQUELCH"]
         self.vfo_memory[self.get_vfo(vfo=vfo)]['squelch'] = sq
@@ -1721,11 +1853,10 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
         if TCP.tcpclient_ready == False:
             radio.connect_process = True
 
+            # Only send STARTUP — the radio's STARTUP_2 response handler
+            # automatically sends L/R_VOLUME_SQUELCH internally, so sending
+            # them here too creates a command storm that locks up the serial
             radio.exe_cmd(cmd=RADIO_TX_CMD.STARTUP)
-            await asyncio.sleep(0.5)
-            radio.exe_cmd(cmd=RADIO_TX_CMD.L_VOLUME_SQUELCH)
-            await asyncio.sleep(0.5)
-            radio.exe_cmd(cmd=RADIO_TX_CMD.R_VOLUME_SQUELCH)
 
         cat_controller = CATController(radio=radio)
         radio.cat = cat_controller
@@ -1828,15 +1959,20 @@ async def read_loop(protocol: SerialProtocol):
             packet = await protocol.receive_queue.get()
 
             if TCP.tcpserver_ready == True and TCP.tcpserver != None:
-                TCP.tcpserver.write(packet+b'\n')
-                await TCP.tcpserver.drain()
+                try:
+                    TCP.tcpserver.write(packet+b'\n')
+                    await TCP.tcpserver.drain()
+                except Exception as e:
+                    print(f"Read loop TCP write error: {e}")
                 packet_processor = SerialPacket(protocol=protocol).process_rx_packet(packet=packet)
             else:
+                print(f"Read loop: no TCP (ready={TCP.tcpserver_ready}, server={TCP.tcpserver is not None}), pkt={packet[:6].hex()}")
                 packet_processor = SerialPacket(protocol=protocol).process_rx_packet(packet=packet)
     except asyncio.CancelledError:
-        printd("Read loop cancelled")
+        print("Read loop cancelled")
     except Exception as e:
         print(f"Read loop error: {e}")
+        import traceback; traceback.print_exc()
 
 async def write_loop(protocol: SerialProtocol):
     global TCP
@@ -1872,7 +2008,7 @@ async def write_loop(protocol: SerialProtocol):
                     print(f"Write loop serial error: {e}")
                     break
     except asyncio.CancelledError:
-        printd("Write loop cancelled")
+        print("Write loop cancelled")
 
 def handle_key_press(sender, app_data):
     global protocol
@@ -2274,7 +2410,7 @@ async def main():
 
     if args.start_server:
         if args.comport and args.baudrate:
-            if args.server_password:
+            if args.server_password is not None:
                 password = args.server_password
             else:
                 print("*Enter password for CAT server*")
@@ -2296,10 +2432,11 @@ async def main():
             while TCP.tcpserver_ready == False:
                 await asyncio.sleep(2)
 
-            asyncio.run_coroutine_threadsafe(
-                connect_serial_async(protocol, args.comport, args.baudrate),
-                loop
-            )
+            # Don't connect serial automatically — let the user connect
+            # via the web UI "Connect" button (avoids STARTUP command storm
+            # that locks up the radio's serial interface)
+            print(f"TCP server ready — waiting for serial connect via web UI or TCP command")
+            print(f"  Serial device: {args.comport} @ {args.baudrate}")
 
             while True:
                 await asyncio.sleep(10)

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -168,7 +168,7 @@ class TCP:
                 data = await reader.readline()
 
                 if not data:
-                    continue
+                    break  # connection closed
 
                 printd(f"Data RCVD: {type(data)} /// {data}")
                 data = data[0:-1] #Pull new line character off the end
@@ -283,10 +283,10 @@ class TCP:
         try:
             while True:
                 data = await reader.readline()
-                
+
                 if not data:
-                    continue
-                
+                    break  # connection closed
+
                 printd(f"Data RCVD: {type(data)} /// {data}")
                 data = data[0:-1] #Pull new line character off the end
                 

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -688,12 +688,32 @@ class SerialProtocol(asyncio.Protocol):
         self._read_task = None
         self._write_task = None
 
+    RTS_STATE_FILE = '/tmp/th9800_rts_state'
+
+    def _save_rts_state(self, state):
+        """Persist RTS state so it survives restarts."""
+        try:
+            with open(self.RTS_STATE_FILE, 'w') as f:
+                f.write('1' if state else '0')
+        except Exception:
+            pass
+
+    @staticmethod
+    def _load_rts_state():
+        """Load saved RTS state. Returns True (USB Controlled) if no saved state."""
+        try:
+            with open(SerialProtocol.RTS_STATE_FILE, 'r') as f:
+                return f.read().strip() == '1'
+        except Exception:
+            return True  # default: USB Controlled
+
     def set_rts(self, state: bool):
         if TCP.tcpclient_ready == True:
             protocol.transmit_queue.put_nowait(f"!rts {state}".encode())
         else:
             printd(f"RTS state: {self.transport.serial.rts} Setting to {state}")
             self.transport.serial.rts = state
+            self._save_rts_state(state)
         if self.radio.dpg_enabled == False:
             return
         match state:
@@ -715,6 +735,7 @@ class SerialProtocol(asyncio.Protocol):
         else:
             state = not self.transport.serial.rts  #Toggle state
             self.transport.serial.rts = state
+            self._save_rts_state(state)
         if self.radio.dpg_enabled == False:
             return
         match state:
@@ -812,9 +833,7 @@ class SerialProtocol(asyncio.Protocol):
             print(f"Connection lost: {exc}")
         else:
             print("Connection closed")
-        # Explicitly lower RTS/DTR so the radio sees a clean disconnect
         try:
-            self.transport.serial.rts = False
             self.transport.serial.dtr = False
         except:
             pass
@@ -1680,7 +1699,10 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
             )
             await protocol.ready.wait()
             protocol.set_dtr(True)
-            protocol.transport.serial.rts = False  # Don't force RTS on connect — let gateway control it
+            # Restore saved RTS state (persists across restarts)
+            saved_rts = SerialProtocol._load_rts_state()
+            protocol.transport.serial.rts = saved_rts
+            protocol.set_rts(saved_rts)  # update UI to match
             await asyncio.sleep(0.5)
 
         if radio.dpg_enabled == True:
@@ -1749,9 +1771,7 @@ def port_selected_callback(sender, app_data, user_data):
             protocol._write_task.cancel()
         protocol._read_task = None
         protocol._write_task = None
-        # Explicitly lower RTS/DTR before closing so the radio sees a clean disconnect
         try:
-            protocol.transport.serial.rts = False
             protocol.transport.serial.dtr = False
         except:
             pass
@@ -2337,9 +2357,7 @@ async def main():
         pass
     finally:
         if protocol.transport != None:
-            # Explicitly lower RTS/DTR before closing so the radio sees a clean disconnect
             try:
-                protocol.transport.serial.rts = False
                 protocol.transport.serial.dtr = False
             except:
                 pass

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -327,9 +327,13 @@ class TCP:
                                 case "True":
                                     dpg.set_value("rts_text", "USB Controlled")
                                     protocol.radio.set_dpg_theme(tag="rts_text",color="green")
+                                    dpg.set_value("fp_rts_text", "USB Controlled")
+                                    protocol.radio.set_dpg_theme(tag="fp_rts_text",color="green")
                                 case "False":
                                     dpg.set_value("rts_text", "Radio Controlled")
                                     protocol.radio.set_dpg_theme(tag="rts_text",color="red")
+                                    dpg.set_value("fp_rts_text", "Radio Controlled")
+                                    protocol.radio.set_dpg_theme(tag="fp_rts_text",color="red")
                         case "dtr":
                             match data:
                                 case "True":
@@ -695,9 +699,13 @@ class SerialProtocol(asyncio.Protocol):
             case True:
                 dpg.set_value("rts_text", "USB Controlled")
                 self.radio.set_dpg_theme(tag="rts_text",color="green")
+                dpg.set_value("fp_rts_text", "USB Controlled")
+                self.radio.set_dpg_theme(tag="fp_rts_text",color="green")
             case False:
                 dpg.set_value("rts_text", "Radio Controlled")
                 self.radio.set_dpg_theme(tag="rts_text",color="red")
+                dpg.set_value("fp_rts_text", "Radio Controlled")
+                self.radio.set_dpg_theme(tag="fp_rts_text",color="red")
 
     def toggle_rts(self):
         if TCP.tcpclient_ready == True:
@@ -712,9 +720,13 @@ class SerialProtocol(asyncio.Protocol):
             case True:
                 dpg.set_value("rts_text", "USB Controlled")
                 self.radio.set_dpg_theme(tag="rts_text",color="green")
+                dpg.set_value("fp_rts_text", "USB Controlled")
+                self.radio.set_dpg_theme(tag="fp_rts_text",color="green")
             case False:
                 dpg.set_value("rts_text", "Radio Controlled")
                 self.radio.set_dpg_theme(tag="rts_text",color="red")
+                dpg.set_value("fp_rts_text", "Radio Controlled")
+                self.radio.set_dpg_theme(tag="fp_rts_text",color="red")
 
     def set_dtr(self, state: bool):
         if TCP.tcpclient_ready == True:
@@ -819,6 +831,9 @@ class SerialProtocol(asyncio.Protocol):
                 dpg.configure_item("rts_button", show=False)
                 dpg.configure_item("rts_text", show=False)
                 dpg.configure_item("rts_label", show=False)
+                dpg.configure_item("fp_rts_button", show=False)
+                dpg.configure_item("fp_rts_text", show=False)
+                dpg.configure_item("fp_rts_label", show=False)
             except:
                 pass  # UI items may not exist yet
 
@@ -1433,10 +1448,14 @@ def tcp_connect_callback(sender, app_data, user_data):
             dpg.configure_item(tag, label="Stop Server")
             dpg.configure_item("rts_button", show=True)
             dpg.configure_item("dtr_button", show=True)
-            
+
             dpg.configure_item("rts_text", show=True)
             dpg.configure_item("rts_label", show=True)
-            
+
+            dpg.configure_item("fp_rts_button", show=True)
+            dpg.configure_item("fp_rts_text", show=True)
+            dpg.configure_item("fp_rts_label", show=True)
+
             dpg.configure_item("tcp_connect_button", show=False)
             dpg.configure_item(tag, show=True)
             dpg.configure_item("connection_window", collapsed=True)
@@ -1456,10 +1475,14 @@ def tcp_connect_callback(sender, app_data, user_data):
             dpg.configure_item("tcp_connect_button", label="Start Server")
             dpg.configure_item("rts_button", show=False)
             dpg.configure_item("dtr_button", show=False)
-            
+
             dpg.configure_item("rts_text", show=False)
             dpg.configure_item("rts_label", show=False)
-            
+
+            dpg.configure_item("fp_rts_button", show=False)
+            dpg.configure_item("fp_rts_text", show=False)
+            dpg.configure_item("fp_rts_label", show=False)
+
             dpg.configure_item("tcp_connect_button", show=True)
             dpg.configure_item("tcp_startserver_button", show=True)
     elif label == "Connect Host":
@@ -1484,10 +1507,14 @@ def tcp_connect_callback(sender, app_data, user_data):
             dpg.configure_item(tag, label="Disconnect Host")
             dpg.configure_item("rts_button", show=True)
             dpg.configure_item("dtr_button", show=True)
-            
+
             dpg.configure_item("rts_text", show=True)
             dpg.configure_item("rts_label", show=True)
-            
+
+            dpg.configure_item("fp_rts_button", show=True)
+            dpg.configure_item("fp_rts_text", show=True)
+            dpg.configure_item("fp_rts_label", show=True)
+
             dpg.configure_item(tag, show=True)
             dpg.configure_item("tcp_startserver_button", show=False)
             dpg.configure_item("connection_window", collapsed=True)
@@ -1505,12 +1532,16 @@ def tcp_connect_callback(sender, app_data, user_data):
             dpg.configure_item("tcp_connect_button", label="Connect Host")
             dpg.configure_item("rts_button", show=False)
             dpg.configure_item("dtr_button", show=False)
-            
+
             dpg.configure_item("rts_text", show=False)
             dpg.configure_item("rts_label", show=False)
-            
+
+            dpg.configure_item("fp_rts_button", show=False)
+            dpg.configure_item("fp_rts_text", show=False)
+            dpg.configure_item("fp_rts_label", show=False)
+
             dpg.configure_item("tcp_connect_button", show=True)
-            
+
             dpg.configure_item("tcp_startserver_button", show=True)
 
 def update_signal(radio: SerialRadio, vfo: RADIO_VFO, s_value: int):
@@ -1657,6 +1688,9 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
             dpg.configure_item("dtr_button", show=True)
             dpg.configure_item("rts_text", show=True)
             dpg.configure_item("rts_label", show=True)
+            dpg.configure_item("fp_rts_button", show=True)
+            dpg.configure_item("fp_rts_text", show=True)
+            dpg.configure_item("fp_rts_label", show=True)
             dpg.configure_item("radio_window", show=True)
             dpg.configure_item("connection_window", collapsed=True)
             dpg.configure_item("connect_button", label="Disconnect")
@@ -1744,6 +1778,9 @@ def port_selected_callback(sender, app_data, user_data):
         dpg.configure_item("rts_button", show=False)
         dpg.configure_item("rts_text", show=False)
         dpg.configure_item("rts_label", show=False)
+        dpg.configure_item("fp_rts_button", show=False)
+        dpg.configure_item("fp_rts_text", show=False)
+        dpg.configure_item("fp_rts_label", show=False)
         return
 
     try:
@@ -1870,6 +1907,14 @@ def build_gui(protocol):
         bold_font = dpg.add_font(bold_font_path, 18)
 
     with dpg.window(tag="radio_window", show=True, label="Radio Front Panel", width=580, height=530, pos=[0,20], no_move=True, no_resize=True, user_data={"protocol": protocol}):
+        # === RTS TX Control ===
+        with dpg.group(horizontal=True):
+            dpg.add_text("RTS TX: ", indent=5, tag="fp_rts_label", show=False)
+            dpg.add_text("USB Controlled", tag="fp_rts_text", show=False)
+            protocol.radio.set_dpg_theme(tag="fp_rts_text", color="green")
+            dpg.add_button(label="Toggle RTS", tag="fp_rts_button", show=False, indent=350, width=100, callback=button_callback, user_data={"label": "Toggle RTS", "protocol": protocol, "vfo": RADIO_VFO.NONE})
+        dpg.add_spacer(height=3)
+
         # === Hyper Mem Buttons A-F ===
         with dpg.group(horizontal=True):
             dpg.add_text("Hyper Memories: ", indent=15)
@@ -2274,6 +2319,9 @@ async def main():
             dpg.configure_item("dtr_button", show=True)
             dpg.configure_item("rts_text", show=True)
             dpg.configure_item("rts_label", show=True)
+            dpg.configure_item("fp_rts_button", show=True)
+            dpg.configure_item("fp_rts_text", show=True)
+            dpg.configure_item("fp_rts_label", show=True)
 
         # Auto-connect to saved serial device if it's present
         comport_value = dpg.get_value("comport")

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -3,7 +3,7 @@ from TH9800_Enums import *
 from time import sleep
 import dearpygui.dearpygui as dpg
 import serial.tools.list_ports,serial_asyncio,asyncio,threading
-import logging,datetime,argparse,platform,ctypes,re,os
+import logging,datetime,argparse,platform,ctypes,re,os,sys
 
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
@@ -823,7 +823,7 @@ class SerialPacket:
                         if self.radio.dpg_enabled == True:
                             dpg.set_value(f"ch_{str(self.radio.vfo_active_processing).lower()}_display",radio_channel)
                             dpg.set_value(f"vfo_{str(self.radio.vfo_active_processing).lower()}_display",radio_text)
-                    case (0x40|0xC0):
+                    case 0x40 | 0xC0:
                         if self.radio.vfo_change == True:
                             return
                         elif self.radio.menu_open == True and self.radio.vfo_active_processing == self.radio.vfo_memory['vfo_active'] and self.radio.connect_process == False:
@@ -1041,7 +1041,7 @@ class SerialPacket:
             enabled_icons = [name for bit, name in icon_map.items() if icon_byte & bit]
             disabled_icons = [name for bit, name in icon_map.items() if not icon_byte & bit]
             if "L" in disabled_icons and "M" in disabled_icons:
-                enabled_icons += "H"
+                enabled_icons += ["H"]
             for icon in enabled_icons:
                 self.radio.set_icon(vfo=vfo,icon=RADIO_RX_ICON[f"{icon}"],value=True)
             for icon in disabled_icons:
@@ -2062,7 +2062,7 @@ async def main():
     if args.server_port:
         if int(args.server_port) < 1024 and is_user_admin == False and platform.system() == "Linux":
             print("Ports below 1024 require admin privileges")
-            exit
+            exit()
 
     if args.start_server:
         if args.comport and args.baudrate:

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -21,6 +21,7 @@ CONFIG_DEFAULTS = {
     "host": "",
     "port": "",
     "password": "",
+    "auto_start_server": "true",
 }
 
 def load_config():
@@ -44,18 +45,19 @@ def save_config(settings):
             f.write(f"{key}={settings.get(key, '')}\n")
 
 def save_current_settings():
+    existing = load_config()
     comport = dpg.get_value("comport")
     device = ""
     if comport and ": " in comport:
         device = comport.split(": ", 1)[1]
-    settings = {
+    existing.update({
         "baud_rate": dpg.get_value("baud_rate"),
         "device": device,
         "host": dpg.get_value("tcp_host_text"),
         "port": dpg.get_value("tcp_port_text"),
         "password": dpg.get_value("tcp_pass_text"),
-    }
-    save_config(settings)
+    })
+    save_config(existing)
 
 def printd(msg):
     if debug == True:
@@ -126,6 +128,18 @@ class TCP:
                 case "data":
                     protocol.send_packet(data=bytearray.fromhex(data))
                     return "data sent"
+                case "vol":
+                    # !vol LEFT 50 or !vol RIGHT 75
+                    parts = data.split() if data else []
+                    if len(parts) == 2:
+                        vfo_str = parts[0].upper()
+                        vol = int(parts[1])
+                        if vfo_str in ("LEFT", "L"):
+                            protocol.radio.set_volume(vfo=RADIO_VFO.LEFT, vol=vol)
+                        elif vfo_str in ("RIGHT", "R"):
+                            protocol.radio.set_volume(vfo=RADIO_VFO.RIGHT, vol=vol)
+                        return f"vol {vfo_str} {vol}"
+                    return "usage: !vol LEFT|RIGHT 0-100"
                 case "rts":
                     if data == None or data == "":
                         protocol.toggle_rts()
@@ -1677,9 +1691,11 @@ async def connect_serial_async(protocol, comport, baudrate, auto_dismiss=False):
         return transport
     except Exception as e:
         print(f"Connection failed: {e}")
-        if radio.dpg_enabled == True:
+        if auto_dismiss:
+            print(f"Auto-connect skipped: {comport} not available")
+        elif radio.dpg_enabled == True:
             with dpg.window(label="Connection Failed", modal=True, no_close=True) as modal_id:
-                dpg.add_text(f"Auto-connect to {comport} failed:\n{e}" if auto_dismiss else e, wrap=300)
+                dpg.add_text(e, wrap=300)
                 dpg.add_button(label="Ok", width=75, user_data=(modal_id, True), callback=cancel_callback)
             dpg.set_item_pos(modal_id, [120, 100])
         return None
@@ -2236,14 +2252,32 @@ async def main():
         dpg.setup_dearpygui()
         dpg.show_viewport()
 
-        # Auto-connect only if a device was previously saved in config.
-        # A blank device field means first run or intentional reset — skip auto-connect.
+        # Ensure event loop is running for auto-start features
+        if not loop.is_running():
+            threading.Thread(target=start_event_loop, daemon=True).start()
+
+        # Auto-start TCP server if configured
+        settings = load_config()
+        if settings.get("auto_start_server", "").lower() != "false":
+            tcp_host = dpg.get_value("tcp_host_text") or "0.0.0.0"
+            tcp_port = dpg.get_value("tcp_port_text") or "9800"
+            tcp_pass = dpg.get_value("tcp_pass_text") or ""
+            TCP.tcpserver_future = asyncio.run_coroutine_threadsafe(
+                TCP.start_tcp_server(host=tcp_host, port=tcp_port, password=tcp_pass, protocol=protocol),
+                loop
+            )
+            dpg.configure_item("tcp_startserver_button", label="Stop Server")
+            dpg.configure_item("tcp_connect_button", show=False)
+            dpg.configure_item("rts_button", show=True)
+            dpg.configure_item("dtr_button", show=True)
+            dpg.configure_item("rts_text", show=True)
+            dpg.configure_item("rts_label", show=True)
+
+        # Auto-connect to saved serial device if it's present
         comport_value = dpg.get_value("comport")
         if saved_device and comport_value and ":" in comport_value:
             auto_comport = comport_value[0:comport_value.index(":")]
             auto_baudrate = dpg.get_value("baud_rate")
-            if not loop.is_running():
-                threading.Thread(target=start_event_loop, daemon=True).start()
             protocol.reset_ready()
             asyncio.run_coroutine_threadsafe(
                 connect_serial_async(protocol, auto_comport, auto_baudrate, auto_dismiss=True),

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -1914,6 +1914,8 @@ def build_gui(protocol):
             protocol.radio.set_dpg_theme(tag="fp_rts_text", color="green")
             dpg.add_button(label="Toggle RTS", tag="fp_rts_button", show=False, indent=350, width=100, callback=button_callback, user_data={"label": "Toggle RTS", "protocol": protocol, "vfo": RADIO_VFO.NONE})
         dpg.add_spacer(height=3)
+        dpg.add_separator()
+        dpg.add_spacer(height=5)
 
         # === Hyper Mem Buttons A-F ===
         with dpg.group(horizontal=True):

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -164,15 +164,18 @@ class TCP:
                 case "ptt":
                     if not (protocol.transport and not protocol.transport.is_closing()):
                         return "serial not connected"
-                    # !ptt — toggle PTT using the same logic as the GUI button
+                    # !ptt [on|off] — explicit key/unkey; bare !ptt toggles (legacy)
                     radio = protocol.radio
-                    if radio.mic_ptt == False:
-                        radio.mic_ptt = True
-                        radio.vfo_memory[radio.vfo_memory['vfo_active']]['ptt'] = 1
-                        radio.exe_cmd(cmd=RADIO_TX_CMD.MIC_PTT)
+                    action = (data or '').strip().lower()
+                    if action == 'on':
+                        desired = True
+                    elif action == 'off':
+                        desired = False
                     else:
-                        radio.mic_ptt = False
-                        radio.vfo_memory[radio.vfo_memory['vfo_active']]['ptt'] = 0
+                        desired = not radio.mic_ptt
+                    if desired != radio.mic_ptt:
+                        radio.mic_ptt = desired
+                        radio.vfo_memory[radio.vfo_memory['vfo_active']]['ptt'] = 1 if desired else 0
                         radio.exe_cmd(cmd=RADIO_TX_CMD.MIC_PTT)
                     return str(radio.mic_ptt)
                 case "dtr":
@@ -349,17 +352,9 @@ class TCP:
                     elif response2 == "Login Successful":
                         writer.write(f"{response2}\n".encode())
                         await writer.drain()
-
-                        # Only run startup sequence if serial is NOT already connected
-                        # (headless mode already ran it — running it again creates a
-                        # command storm that overwhelms the radio's serial interface)
-                        if not (protocol.transport and not protocol.transport.is_closing()):
-                            protocol.radio.connect_process = True
-                            protocol.radio.exe_cmd(cmd=RADIO_TX_CMD.STARTUP)
-                            await asyncio.sleep(3)
-                        else:
-                            print("Serial already connected, skipping post-login startup")
-
+                        # Do NOT send STARTUP here — the !serial connect handler owns
+                        # the STARTUP sequence. Sending it here too causes a double-STARTUP
+                        # that overwhelms the radio (RIGHT VFO goes dead).
                         continue
                     else:
                         response += response2

--- a/TH9800_CAT.py
+++ b/TH9800_CAT.py
@@ -2415,17 +2415,18 @@ async def main():
             radio.dpg_enabled = False
             print("\nStarting command line server...")
 
-            if not loop.is_running():
-                threading.Thread(target=start_event_loop, daemon=True).start()
-                protocol.reset_ready()
-
-            TCP.tcpserver_future = asyncio.run_coroutine_threadsafe(
-                TCP.start_tcp_server(host=args.server_host_ip, port=args.server_port, password=password, protocol=protocol),
-                loop
-            )
+            # Single-loop headless: main() runs on the module-level `loop`
+            # (see __main__), so the TCP server, shutdown event, and serial
+            # callbacks all share one event loop. Earlier versions spun a
+            # second loop via asyncio.run() which meant the signal handler
+            # set the event on the wrong loop — shutdown hung until SIGKILL.
+            tcp_task = asyncio.create_task(
+                TCP.start_tcp_server(
+                    host=args.server_host_ip, port=args.server_port,
+                    password=password, protocol=protocol))
 
             while TCP.tcpserver_ready == False:
-                await asyncio.sleep(2)
+                await asyncio.sleep(0.1)
 
             # Don't connect serial automatically — let the user connect
             # via the web UI "Connect" button (avoids STARTUP command storm
@@ -2433,21 +2434,18 @@ async def main():
             print(f"TCP server ready — waiting for serial connect via web UI or TCP command")
             print(f"  Serial device: {args.comport} @ {args.baudrate}")
 
-            # Register SIGTERM handler so systemd stop triggers clean shutdown
-            import signal
-            _shutdown_event = asyncio.Event()
-            def _sigterm_handler(signum, frame):
-                print("\nSIGTERM received — shutting down...")
-                loop.call_soon_threadsafe(_shutdown_event.set)
-            signal.signal(signal.SIGTERM, _sigterm_handler)
-            signal.signal(signal.SIGINT, _sigterm_handler)
+            # The shutdown Event lives on this (module) loop. The POSIX signal
+            # handler is installed in __main__ on the main thread (add_signal_handler
+            # can't be used here — main() runs on the loop's background thread) and
+            # wakes us via loop.call_soon_threadsafe(_shutdown_event.set).
+            global _headless_shutdown_event
+            _headless_shutdown_event = asyncio.Event()
 
             try:
-                await _shutdown_event.wait()
+                await _headless_shutdown_event.wait()
             except (asyncio.CancelledError, KeyboardInterrupt):
                 pass
             finally:
-                # Clean up serial connection
                 if protocol.transport and not protocol.transport.is_closing():
                     print("  Closing serial port...")
                     try:
@@ -2455,18 +2453,18 @@ async def main():
                     except Exception:
                         pass
                     protocol.transport.close()
-                # Clean up TCP server
-                if TCP.tcpserver is not None:
-                    try:
-                        TCP.tcpserver.close()
-                    except Exception:
-                        pass
                 if TCP.tcpserver_server is not None:
                     try:
                         TCP.tcpserver_server.close()
+                        await TCP.tcpserver_server.wait_closed()
                     except Exception:
                         pass
                 TCP.tcpserver_ready = False
+                tcp_task.cancel()
+                try:
+                    await tcp_task
+                except (asyncio.CancelledError, Exception):
+                    pass
                 print("  Headless server shut down cleanly.")
             return  # Skip GUI path below
         else:
@@ -2531,5 +2529,25 @@ async def main():
         if radio.dpg_enabled == True:
             dpg.destroy_context()
 
+_headless_shutdown_event = None  # set by main() once the loop binds it
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    # Headless mode runs on the module-level `loop` (started at import by the
+    # background thread at line 72). asyncio.run() would create a second loop
+    # and leave the TCP server + signal handler straddling two event loops,
+    # which is the exact bug that caused the 10 s SIGKILL hang on systemd stop.
+    if any(a in sys.argv for a in ("-s", "--start-server")):
+        import signal as _signal
+        def _shutdown(_signum, _frame):
+            print("\nSIGTERM received — shutting down...")
+            if _headless_shutdown_event is not None:
+                loop.call_soon_threadsafe(_headless_shutdown_event.set)
+        _signal.signal(_signal.SIGTERM, _shutdown)
+        _signal.signal(_signal.SIGINT, _shutdown)
+        fut = asyncio.run_coroutine_threadsafe(main(), loop)
+        try:
+            fut.result()
+        except KeyboardInterrupt:
+            pass
+    else:
+        asyncio.run(main())

--- a/install.sh
+++ b/install.sh
@@ -132,6 +132,26 @@ install_dearpygui_prebuilt() {
     fi
 }
 
+install_dearpygui_from_wheel() {
+    # Check for a cached local wheel before building from source.
+    # Looks in project dist/ and ~/dist/ for a matching platform wheel.
+    local wheel=""
+    for dir in "$SCRIPT_DIR/dist" "$HOME/dist"; do
+        if [ -d "$dir" ]; then
+            wheel=$(find "$dir" -name "dearpygui-*-$PLAT.whl" -print -quit 2>/dev/null)
+            [ -n "$wheel" ] && break
+        fi
+    done
+
+    if [ -n "$wheel" ]; then
+        echo "  Found cached wheel: $wheel"
+        "$PIP" install "$wheel"
+        echo "  dearpygui installed from cached wheel."
+        return 0
+    fi
+    return 1
+}
+
 install_dearpygui_from_source() {
     echo "  ARM detected ($ARCH) — building dearpygui from source."
     echo "  This may take several minutes on lower-end boards."
@@ -154,15 +174,13 @@ install_dearpygui_from_source() {
 
     cd "$BUILD_TMP/DearPyGui"
 
-    if [[ "$ARCH" == "armv7l" ]]; then
-        PLAT="linux_armv7l"
-    else
-        # aarch64 / arm64
-        PLAT="linux_aarch64"
-    fi
-
     # setup.py must be run as a script, not with -m
     "$PYTHON" setup.py bdist_wheel --plat-name "$PLAT" --dist-dir "$BUILD_TMP/dist"
+
+    # Cache the wheel in the project dist/ directory for future installs
+    mkdir -p "$SCRIPT_DIR/dist"
+    cp "$BUILD_TMP"/dist/dearpygui-*.whl "$SCRIPT_DIR/dist/"
+    echo "  Wheel cached in $SCRIPT_DIR/dist/"
 
     "$PIP" install "$BUILD_TMP"/dist/dearpygui-*.whl
 
@@ -173,14 +191,20 @@ install_dearpygui_from_source() {
 case "$ARCH" in
     x86_64|i686|amd64)
         # Prebuilt wheels are available for x86; try pinned version, fall back to latest.
+        PLAT="linux_x86_64"
         install_dearpygui_prebuilt
         ;;
-    armv7l|aarch64|arm64)
-        # No prebuilt ARM wheels exist on PyPI — source build is required.
-        install_dearpygui_from_source
+    armv7l)
+        PLAT="linux_armv7l"
+        install_dearpygui_from_wheel || install_dearpygui_from_source
+        ;;
+    aarch64|arm64)
+        PLAT="linux_aarch64"
+        install_dearpygui_from_wheel || install_dearpygui_from_source
         ;;
     *)
         echo "  Unknown architecture ($ARCH), attempting prebuilt install ..."
+        PLAT="unknown"
         install_dearpygui_prebuilt
         ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -18,17 +18,45 @@ fi
 PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 echo "Python version: $PY_VER"
 
+# ── Detect package manager ────────────────────────────────────────────────
+if command -v pacman &>/dev/null; then
+    PKG_MGR="pacman"
+elif command -v apt-get &>/dev/null; then
+    PKG_MGR="apt"
+else
+    PKG_MGR="unknown"
+fi
+
+pkg_installed() {
+    case "$PKG_MGR" in
+        pacman)  pacman -Qi "$1" &>/dev/null ;;
+        apt)     dpkg -s "$1" &>/dev/null 2>&1 ;;
+        *)       return 1 ;;
+    esac
+}
+
+pkg_install() {
+    case "$PKG_MGR" in
+        pacman)  sudo pacman -S --needed --noconfirm "$@" ;;
+        apt)     sudo apt-get install -y "$@" ;;
+        *)       echo "ERROR: No supported package manager found."; exit 1 ;;
+    esac
+}
+
 # ── 2. Ensure python3-venv is available, then create virtual environment ────
 echo ""
 echo "[1/4] Creating virtual environment at $VENV_DIR ..."
 
-# On Debian/Ubuntu, python3-venv and ensurepip ship in a separate package.
-# Always ensure it's installed — apt is a no-op if already present.
-if dpkg -s "python${PY_VER}-venv" &>/dev/null 2>&1; then
-    echo "  python${PY_VER}-venv already installed."
+if [ "$PKG_MGR" = "apt" ]; then
+    # On Debian/Ubuntu, python3-venv ships in a separate package.
+    if pkg_installed "python${PY_VER}-venv"; then
+        echo "  python${PY_VER}-venv already installed."
+    else
+        echo "  Installing python${PY_VER}-venv ..."
+        pkg_install "python${PY_VER}-venv"
+    fi
 else
-    echo "  Installing python${PY_VER}-venv ..."
-    sudo apt-get install -y "python${PY_VER}-venv"
+    echo "  venv is included with python3 on this distro."
 fi
 
 # Treat a venv with no pip binary as broken (e.g. from a failed prior run)
@@ -52,15 +80,22 @@ PYTHON="$VENV_DIR/bin/python"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     echo ""
     echo "[2/4] Checking system dependencies for dearpygui ..."
+
+    if [ "$PKG_MGR" = "pacman" ]; then
+        SYS_PKGS=(glu mesa libxrandr libxinerama libxcursor libxi)
+    else
+        SYS_PKGS=(libglu1-mesa libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev)
+    fi
+
     MISSING_PKGS=()
-    for pkg in libglu1-mesa libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev; do
-        if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
+    for pkg in "${SYS_PKGS[@]}"; do
+        if ! pkg_installed "$pkg"; then
             MISSING_PKGS+=("$pkg")
         fi
     done
     if [ ${#MISSING_PKGS[@]} -gt 0 ]; then
         echo "  Installing missing system packages: ${MISSING_PKGS[*]}"
-        sudo apt-get install -y "${MISSING_PKGS[@]}"
+        pkg_install "${MISSING_PKGS[@]}"
     else
         echo "  All system dependencies already present."
     fi
@@ -101,10 +136,14 @@ install_dearpygui_from_source() {
     echo "  ARM detected ($ARCH) — building dearpygui from source."
     echo "  This may take several minutes on lower-end boards."
 
-    # Build deps (some may already be installed from step 2, apt is idempotent)
-    sudo apt-get install -y git cmake python3 python3-dev \
-        libglu1-mesa-dev libgl1-mesa-dev \
-        libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+    # Build deps
+    if [ "$PKG_MGR" = "pacman" ]; then
+        pkg_install git cmake python glu mesa libxrandr libxinerama libxcursor libxi
+    else
+        pkg_install git cmake python3 python3-dev \
+            libglu1-mesa-dev libgl1-mesa-dev \
+            libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+    fi
 
     BUILD_TMP=$(mktemp -d)
     # Clean up build directory on exit regardless of success or failure

--- a/install.sh
+++ b/install.sh
@@ -217,9 +217,54 @@ exec "\$(dirname "\${BASH_SOURCE[0]}")/venv/bin/python" TH9800_CAT.py "\$@"
 EOF
 chmod +x "$SCRIPT_DIR/run.sh"
 
+# ── Install systemd service ───────────────────────────────────────────────────
+echo ""
+echo "[5/5] Installing systemd service ..."
+
+SERVICE_FILE="/etc/systemd/system/th9800-cat.service"
+CURRENT_USER="$(whoami)"
+HEADLESS_SH="$SCRIPT_DIR/run-headless.sh"
+
+sudo tee "$SERVICE_FILE" > /dev/null << SVCEOF
+[Unit]
+Description=TH-9800 CAT Control Server (headless)
+After=network.target
+Before=radio-gateway.service
+
+[Service]
+Type=simple
+User=$CURRENT_USER
+Group=$CURRENT_USER
+WorkingDirectory=$SCRIPT_DIR
+ExecStart=$HEADLESS_SH
+KillMode=control-group
+KillSignal=SIGTERM
+TimeoutStopSec=10
+
+Restart=on-failure
+RestartSec=5
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=th9800-cat
+
+# Serial port access
+SupplementaryGroups=uucp
+
+Environment=HOME=$HOME
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable th9800-cat.service
+echo "  Service installed and enabled: th9800-cat.service"
+
 # ── Done ─────────────────────────────────────────────────────────────────────
 echo ""
 echo "=== Installation complete ==="
 echo ""
-echo "To run the app:"
-echo "  ./run.sh"
+echo "To run standalone:  ./run.sh"
+echo "As a service:       sudo systemctl start th9800-cat"
+echo "View logs:          journalctl -u th9800-cat -f"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/venv"
+ARCH="$(uname -m)"
+
+echo "=== TH9800_CAT Installer ==="
+echo "Architecture : $ARCH"
+echo "Project dir  : $SCRIPT_DIR"
+echo ""
+
+# ── 1. Python 3 sanity check ────────────────────────────────────────────────
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 not found. Install Python 3.9+ and re-run."
+    exit 1
+fi
+PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "Python version: $PY_VER"
+
+# ── 2. Ensure python3-venv is available, then create virtual environment ────
+echo ""
+echo "[1/4] Creating virtual environment at $VENV_DIR ..."
+
+# On Debian/Ubuntu, python3-venv and ensurepip ship in a separate package.
+# Always ensure it's installed — apt is a no-op if already present.
+if dpkg -s "python${PY_VER}-venv" &>/dev/null 2>&1; then
+    echo "  python${PY_VER}-venv already installed."
+else
+    echo "  Installing python${PY_VER}-venv ..."
+    sudo apt-get install -y "python${PY_VER}-venv"
+fi
+
+# Treat a venv with no pip binary as broken (e.g. from a failed prior run)
+if [ -d "$VENV_DIR" ] && [ ! -f "$VENV_DIR/bin/pip" ]; then
+    echo "  Incomplete venv detected — removing and recreating ..."
+    rm -rf "$VENV_DIR"
+fi
+
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+else
+    echo "  Virtual environment already exists, skipping creation."
+fi
+
+PIP="$VENV_DIR/bin/pip"
+PYTHON="$VENV_DIR/bin/python"
+
+"$PIP" install --upgrade pip --quiet
+
+# ── 3. System-level dependencies (Linux only, needed by dearpygui) ──────────
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo ""
+    echo "[2/4] Checking system dependencies for dearpygui ..."
+    MISSING_PKGS=()
+    for pkg in libglu1-mesa libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev; do
+        if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
+            MISSING_PKGS+=("$pkg")
+        fi
+    done
+    if [ ${#MISSING_PKGS[@]} -gt 0 ]; then
+        echo "  Installing missing system packages: ${MISSING_PKGS[*]}"
+        sudo apt-get install -y "${MISSING_PKGS[@]}"
+    else
+        echo "  All system dependencies already present."
+    fi
+fi
+
+# ── 4. Install Python packages ───────────────────────────────────────────────
+echo ""
+echo "[3/4] Installing Python packages ..."
+
+# asyncio is part of the Python standard library (since 3.4).
+# The standalone PyPI package (asyncio==3.4.3) is deprecated, conflicts with
+# the built-in module on Python 3.5+, and fails to install on Python 3.12+.
+# It is intentionally skipped here.
+echo "  Skipping 'asyncio' — already built into Python $PY_VER (stdlib)"
+
+"$PIP" install "pyserial==3.5"
+"$PIP" install "pyserial-asyncio==0.6"
+
+# ── 5. dearpygui — handle prebuilt vs. source-build ─────────────────────────
+echo ""
+echo "[4/4] Installing dearpygui ..."
+
+install_dearpygui_prebuilt() {
+    # Try the pinned version first; fall back to latest if no wheel exists for
+    # this Python version (e.g. cp313 wheel missing for 2.0.0).
+    if "$PIP" install "dearpygui==2.0.0" 2>/dev/null; then
+        echo "  dearpygui 2.0.0 installed successfully."
+    else
+        echo "  No prebuilt wheel for dearpygui 2.0.0 on Python $PY_VER."
+        echo "  Falling back to latest available release ..."
+        "$PIP" install dearpygui
+        DPG_VER=$("$PYTHON" -c "import dearpygui; print(dearpygui.__version__)" 2>/dev/null || echo "unknown")
+        echo "  dearpygui $DPG_VER installed."
+    fi
+}
+
+install_dearpygui_from_source() {
+    echo "  ARM detected ($ARCH) — building dearpygui from source."
+    echo "  This may take several minutes on lower-end boards."
+
+    # Build deps (some may already be installed from step 2, apt is idempotent)
+    sudo apt-get install -y git cmake python3 python3-dev \
+        libglu1-mesa-dev libgl1-mesa-dev \
+        libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+
+    BUILD_TMP=$(mktemp -d)
+    # Clean up build directory on exit regardless of success or failure
+    cleanup() { rm -rf "$BUILD_TMP"; }
+    trap cleanup EXIT
+
+    git clone --recursive https://github.com/hoffstadt/DearPyGui "$BUILD_TMP/DearPyGui"
+
+    cd "$BUILD_TMP/DearPyGui"
+
+    if [[ "$ARCH" == "armv7l" ]]; then
+        PLAT="linux_armv7l"
+    else
+        # aarch64 / arm64
+        PLAT="linux_aarch64"
+    fi
+
+    # setup.py must be run as a script, not with -m
+    "$PYTHON" setup.py bdist_wheel --plat-name "$PLAT" --dist-dir "$BUILD_TMP/dist"
+
+    "$PIP" install "$BUILD_TMP"/dist/dearpygui-*.whl
+
+    cd "$SCRIPT_DIR"
+    echo "  dearpygui built and installed from source."
+}
+
+case "$ARCH" in
+    x86_64|i686|amd64)
+        # Prebuilt wheels are available for x86; try pinned version, fall back to latest.
+        install_dearpygui_prebuilt
+        ;;
+    armv7l|aarch64|arm64)
+        # No prebuilt ARM wheels exist on PyPI — source build is required.
+        install_dearpygui_from_source
+        ;;
+    *)
+        echo "  Unknown architecture ($ARCH), attempting prebuilt install ..."
+        install_dearpygui_prebuilt
+        ;;
+esac
+
+# ── Create run.sh wrapper ─────────────────────────────────────────────────────
+cat > "$SCRIPT_DIR/run.sh" << EOF
+#!/usr/bin/env bash
+cd "\$(dirname "\${BASH_SOURCE[0]}")"
+exec "\$(dirname "\${BASH_SOURCE[0]}")/venv/bin/python" TH9800_CAT.py "\$@"
+EOF
+chmod +x "$SCRIPT_DIR/run.sh"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Installation complete ==="
+echo ""
+echo "To run the app:"
+echo "  ./run.sh"

--- a/run-headless.sh
+++ b/run-headless.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# TH9800_CAT — headless server launcher
+# Reads config.txt for device/baud, resolves the serial port, and starts
+# the TCP server without GUI.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON="$SCRIPT_DIR/venv/bin/python"
+CONFIG="$SCRIPT_DIR/config.txt"
+
+# Read a value from config.txt
+read_cfg() {
+    local key="$1" default="$2"
+    local val
+    val="$(grep -m1 "^${key}=" "$CONFIG" 2>/dev/null | cut -d= -f2- | sed 's/^[[:space:]]*//')"
+    if [ -z "$val" ]; then echo "$default"; else echo "$val"; fi
+}
+
+BAUD="$(read_cfg baud_rate 19200)"
+DEVICE_NAME="$(read_cfg device "")"
+HOST="$(read_cfg host 0.0.0.0)"
+PORT="$(read_cfg port 9800)"
+PASSWORD="$(read_cfg password "")"
+
+# Also check gateway config for port/password overrides
+GW_CONFIG="$HOME/Downloads/radio-gateway/gateway_config.txt"
+if [ -f "$GW_CONFIG" ]; then
+    GW_PORT="$(grep -m1 '^[[:space:]]*CAT_PORT' "$GW_CONFIG" 2>/dev/null \
+        | sed 's/^[^=]*=[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d "'\"")"
+    GW_PASS="$(grep -m1 '^[[:space:]]*CAT_PASSWORD' "$GW_CONFIG" 2>/dev/null \
+        | sed 's/^[^=]*=[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d "'\"")"
+    [ -n "$GW_PORT" ] && PORT="$GW_PORT"
+    [ -n "$GW_PASS" ] && PASSWORD="$GW_PASS"
+fi
+
+# Resolve serial device by matching description
+COMPORT=""
+if [ -n "$DEVICE_NAME" ]; then
+    COMPORT="$("$PYTHON" -c "
+import serial.tools.list_ports
+for p in serial.tools.list_ports.comports():
+    if '$DEVICE_NAME' in p.description:
+        print(p.device)
+        break
+" 2>/dev/null)"
+fi
+
+if [ -z "$COMPORT" ]; then
+    echo "ERROR: No serial device matching '$DEVICE_NAME' found"
+    echo "Available ports:"
+    "$PYTHON" -c "import serial.tools.list_ports; [print(f'  {p.device}: {p.description}') for p in serial.tools.list_ports.comports()]" 2>/dev/null
+    exit 1
+fi
+
+echo "Starting headless: $COMPORT @ $BAUD, port $PORT"
+cd "$SCRIPT_DIR"
+exec "$PYTHON" -u TH9800_CAT.py \
+    -s -c "$COMPORT" -b "$BAUD" \
+    -p "$PASSWORD" -sH "$HOST" -sP "$PORT"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname "${BASH_SOURCE[0]}")"
+exec "$(dirname "${BASH_SOURCE[0]}")/venv/bin/python" TH9800_CAT.py "$@"


### PR DESCRIPTION
## Summary

### Bug fixes (initial)
- Add missing `sys` import — `sys.platform` on line 196 causes `NameError` at runtime
- Fix match/case OR pattern — `case (0x40|0xC0):` parens forced bitwise eval to `0xC0`, only matching one value instead of both; removed parens for proper OR pattern
- Fix list append — `enabled_icons += "H"` to `+= ["H"]` for correct list semantics
- Fix `exit` to `exit()` so the function is actually called when port < 1024 on Linux
- Add `.gitignore` for `__pycache__/`, `venv/`, `*.pyc`
- Add project docs (`docs/MEMORY.md`, `docs/architecture.md`)

### Serial connection fixes
- **Fix connection hang**: Removed `loop.stop()` from `connection_lost` that killed the entire asyncio event loop, requiring manual reconnect to recover
- **Fix unclean disconnect**: Track and cancel read/write loop tasks on disconnect, drain stale queues, clear buffer, and explicitly lower RTS/DTR before closing the serial transport so the radio sees a clean disconnect (prevents "must connect twice" on next session)
- **Fix write_loop exception handling**: Replaced bare `except: None` with specific handling for `TimeoutError`, `ConnectionError`, `OSError`, and `SerialException` — errors are now logged instead of silently swallowed
- **Fix operator precedence** in `send_packet` condition
- **Fix modal dialog dismiss**: `cancel_callback` now handles both tuple and plain `user_data` formats, and uses `delete_item` instead of `configure_item(show=False)` to properly remove modal dialogs
- **Fix reconnect reliability**: `protocol.ready` is now reset on every reconnect attempt, not just when the event loop was dead

### Persistent config and startup behavior
- **Persistent config file** (`config.txt`): saves baud rate, device, TCP host/port/password across sessions
- **TCP server auto-starts** on launch unless `auto_start_server=false` in config — GUI buttons update to reflect running state
- **Serial auto-connect**: attempts connection to saved device if it's present and detected; silently skips if device is absent or unresponsive (no blocking error dialog)
- **TCP `!vol` command**: set radio volume remotely via `!vol LEFT|RIGHT 0-100`

### Documentation and scripts
- Install script (`install.sh`) and run script (`run.sh`) for easy setup
- Updated README with install/run instructions and fork notes

## Test plan
- [ ] Verify app launches without `NameError` on `sys.platform` (Linux path, line 196)
- [ ] Verify display packets with `0x40` are handled correctly (previously only `0xC0` matched)
- [ ] Verify power icon "H" displays correctly when L and M are both disabled
- [ ] Verify `--server-port` with port < 1024 as non-root on Linux actually exits
- [ ] Connect to radio via serial — verify startup commands get responses on first connect
- [ ] Disconnect and reconnect — verify clean reconnect without needing to toggle twice
- [ ] Close the app with X button, relaunch, connect — verify first connect works
- [ ] Click Connect with no valid port selected — verify error dialog dismisses properly with Ok button
- [ ] Unplug USB cable while connected — verify app doesn't hang and UI resets to disconnected state
- [ ] Launch app with radio plugged in — verify TCP server starts and serial auto-connects
- [ ] Launch app without radio plugged in — verify TCP server starts, serial silently skips
- [ ] Set `auto_start_server=false` in config.txt — verify TCP server does not auto-start
- [ ] Verify config.txt persists settings across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)